### PR TITLE
fix(music): boxed, uncropped album art in the music controller

### DIFF
--- a/app/src/main/java/com/example/ava/ui/components/GlassMusicPlayerView.kt
+++ b/app/src/main/java/com/example/ava/ui/components/GlassMusicPlayerView.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.*
@@ -99,9 +100,10 @@ fun GlassMusicPlayerView(
         label = "glowScale"
     )
     
-    // Background blur/opacity transition based on playing state
-    val targetBlur = if (isPlaying) 0.dp else 20.dp
-    val targetOpacity = if (isPlaying) 0.7f else 0.4f
+    // Background stays softly blurred at all times so the cover reads as an ambient wash,
+    // not a full-bleed cropped image. The sharp, un-cropped cover is shown boxed in the foreground.
+    val targetBlur = if (isPlaying) 28.dp else 20.dp
+    val targetOpacity = if (isPlaying) 0.6f else 0.4f
     
     val backgroundBlur by animateDpAsState(targetValue = targetBlur, animationSpec = tween(800), label = "blur")
     val backgroundOpacity by animateFloatAsState(targetValue = targetOpacity, animationSpec = tween(800), label = "opacity")
@@ -198,50 +200,58 @@ fun GlassMusicPlayerView(
         val topPadding = if (isLandscape) 60.dp else 80.dp
         val bottomPadding = if (isLandscape) 40.dp else 60.dp
         
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(start = horizontalPadding, end = horizontalPadding, top = topPadding, bottom = bottomPadding),
-            verticalArrangement = Arrangement.Bottom
-        ) {
-
-            Column(modifier = Modifier.padding(bottom = 10.dp)) {
-                ShimmerText(
-                    text = songTitle,
-                    modifier = Modifier.padding(bottom = 10.dp)
-                )
-                
-                Column {
-                    Text(
-                        text = artistName,
-                        color = Color.White.copy(alpha = 0.55f),
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Normal,
-                        letterSpacing = 0.5.sp
-                    )
-                    Spacer(modifier = Modifier.height(6.dp))
-                    Box(
-                        modifier = Modifier
-                            .width(40.dp)
-                            .height(2.dp)
-                            .background(
-                                Color.White.copy(alpha = 0.3f),
-                                RoundedCornerShape(4.dp)
-                            )
+        // Boxed, CONTAINED album cover (never cropped) — the sharp hero artwork.
+        // Fixes full-bleed cropping: the cover is fit inside a rounded square instead of
+        // filling/cropping the whole screen (that role is now the soft blurred backdrop).
+        val albumCover: @Composable (Modifier) -> Unit = { coverModifier ->
+            Box(
+                modifier = coverModifier
+                    .aspectRatio(1f)
+                    .shadow(22.dp, RoundedCornerShape(18.dp))
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(Color(0xFF0B0906))
+            ) {
+                if (coverBitmap != null) {
+                    androidx.compose.foundation.Image(
+                        bitmap = coverBitmap.asImageBitmap(),
+                        contentDescription = "Album cover",
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxSize()
                     )
                 }
             }
-            
-            
-            Spacer(modifier = Modifier.height(20.dp))
+        }
 
+        val trackInfo: @Composable () -> Unit = {
+            ShimmerText(
+                text = songTitle,
+                modifier = Modifier.padding(bottom = 10.dp)
+            )
+            Text(
+                text = artistName,
+                color = Color.White.copy(alpha = 0.55f),
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Normal,
+                letterSpacing = 0.5.sp
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Box(
+                modifier = Modifier
+                    .width(40.dp)
+                    .height(2.dp)
+                    .background(
+                        Color.White.copy(alpha = 0.3f),
+                        RoundedCornerShape(4.dp)
+                    )
+            )
+        }
 
+        val controls: @Composable () -> Unit = {
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = if (isLandscape) Arrangement.Center else Arrangement.SpaceEvenly,
+                horizontalArrangement = if (isLandscape) Arrangement.Start else Arrangement.SpaceEvenly,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-
                 ControlButton(onClick = onShuffleClick) {
                     IconWithShadow(
                         imageVector = Icons.Filled.Shuffle,
@@ -250,10 +260,7 @@ fun GlassMusicPlayerView(
                         size = if (isLandscape) 28.dp else 24.dp
                     )
                 }
-                
-                if (isLandscape) Spacer(modifier = Modifier.width(40.dp))
-                
-
+                if (isLandscape) Spacer(modifier = Modifier.width(32.dp))
                 ControlButton(onClick = onPreviousClick) {
                     IconWithShadow(
                         imageVector = Icons.Filled.SkipPrevious,
@@ -262,18 +269,12 @@ fun GlassMusicPlayerView(
                         size = if (isLandscape) 36.dp else 30.dp
                     )
                 }
-                
-                if (isLandscape) Spacer(modifier = Modifier.width(40.dp))
-                
-                // Play/Pause
+                if (isLandscape) Spacer(modifier = Modifier.width(32.dp))
                 GlassPlayButton(
                     isPlaying = isPlaying,
                     onClick = onPlayPauseClick
                 )
-                
-                if (isLandscape) Spacer(modifier = Modifier.width(40.dp))
-                
-
+                if (isLandscape) Spacer(modifier = Modifier.width(32.dp))
                 ControlButton(onClick = onNextClick) {
                     IconWithShadow(
                         imageVector = Icons.Filled.SkipNext,
@@ -282,10 +283,7 @@ fun GlassMusicPlayerView(
                         size = if (isLandscape) 36.dp else 30.dp
                     )
                 }
-                
-                if (isLandscape) Spacer(modifier = Modifier.width(40.dp))
-                
-
+                if (isLandscape) Spacer(modifier = Modifier.width(32.dp))
                 ControlButton(onClick = onRepeatClick) {
                     when (repeatMode) {
                         "one" -> IconWithShadow(
@@ -308,6 +306,42 @@ fun GlassMusicPlayerView(
                         )
                     }
                 }
+            }
+        }
+
+        if (isLandscape) {
+            // Landscape: boxed cover on the left, track info + controls on the right.
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = horizontalPadding, vertical = bottomPadding),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(48.dp)
+            ) {
+                albumCover(Modifier.fillMaxHeight(0.78f))
+                Column(modifier = Modifier.weight(1f)) {
+                    trackInfo()
+                    Spacer(modifier = Modifier.height(28.dp))
+                    controls()
+                }
+            }
+        } else {
+            // Portrait: boxed cover on top, track info + controls below.
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(start = horizontalPadding, end = horizontalPadding, top = topPadding, bottom = bottomPadding),
+                verticalArrangement = Arrangement.Bottom
+            ) {
+                albumCover(
+                    Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .fillMaxWidth(0.62f)
+                        .padding(bottom = 28.dp)
+                )
+                trackInfo()
+                Spacer(modifier = Modifier.height(20.dp))
+                controls()
             }
         }
     }


### PR DESCRIPTION
## Problem

On wide screens (e.g. the Amazon Echo Show 5's 960×480 display) the music controller shows the album art **full-bleed and cropped** — the sides and top of the cover are cut off, and there's no boxed artwork anywhere.

The cause is in `GlassMusicPlayerView.kt`: the cover is drawn as a `ContentScale.Crop` background at `fillMaxSize()`, and the background blur is animated to **`0.dp` while playing** — so during playback the cover fills and crops the whole screen.

## Fix

- Keep that cover only as a **soft, always-blurred ambient backdrop** (the blur no longer drops to `0.dp` while playing).
- Add a **boxed, `ContentScale.Fit` (contained) cover** as the sharp hero, so the artwork is never cropped:
  - **Landscape:** cover on the left, title / artist / controls on the right.
  - **Portrait:** cover on top, info + controls below.
- All existing controls (shuffle / previous / play-pause / next / repeat), the shimmer title, artist name and accent line are preserved. Single file changed.

## Before / After

These are **real renders of `GlassMusicPlayerView.kt`** (before = the original, after = this PR), rendered in isolation with **Paparazzi** at 960×480 landscape, `isPlaying = true`, same cover/title/artist both times. The component is self-contained (only Compose deps), so it renders standalone — including the `Modifier.blur` ambient backdrop.

**Before** — the cover fills and crops the whole screen while playing:

![Before — full-bleed cropped cover](https://raw.githubusercontent.com/ds2000/Ava/pr-assets/pr-before3.png)

**After** — the full cover sits contained in a rounded box on a soft blurred backdrop, cover-left / info-right:

![After — boxed, contained cover](https://raw.githubusercontent.com/ds2000/Ava/pr-assets/pr-after3.png)

## Testing note

- The changed file **passes Kotlin (K2) frontend analysis cleanly — 0 errors** (Gradle + JDK 21 + Android SDK 36).
- It also **renders correctly in isolation** (Paparazzi 1.3.5, Compose BOM 2024.06, at 960×480) — the before/after above are those renders, not mockups.

Heads-up unrelated to this change: a fresh `master` clone didn't compile as a whole in my environment — several symbols (`MainNavHost`, `MdiIconMapper`, the `VoiceSatellite*` state, some theme colors) are referenced but not present in the public tree, so `compileDebugKotlin` / CI will fail on those **pre-existing** errors. Confirmed with a control build (reverting only this file to its parent gives the identical error set). Happy to tweak the layout numbers (cover size / spacing) to taste.
