### PR TITLE
Fix camera on single-lens devices: filter() returns empty, never throws

### DIFF
--- a/android/app/src/main/java/com/example/ava/camera/CameraCapture.kt
+++ b/android/app/src/main/java/com/example/ava/camera/CameraCapture.kt
@@ -183,14 +183,27 @@ class CameraCapture(private val context: Context) {
             true -> CameraSelector.DEFAULT_FRONT_CAMERA
             false -> CameraSelector.DEFAULT_BACK_CAMERA
         }
-        
-        return runCatching {
-            preferredSelector.filter(provider.availableCameraInfos)
-            preferredSelector
-        }.getOrElse {
-            
-            CameraSelector.Builder().build()
+        val fallbackSelector = when (useFrontCamera) {
+            true -> CameraSelector.DEFAULT_BACK_CAMERA
+            false -> CameraSelector.DEFAULT_FRONT_CAMERA
         }
+
+        val availableCameras = runCatching { provider.availableCameraInfos }.getOrElse { emptyList() }
+
+
+        for (selector in listOf(preferredSelector, fallbackSelector)) {
+            val matches = runCatching { selector.filter(availableCameras) }.getOrElse { emptyList() }
+            if (matches.isNotEmpty()) {
+                if (selector !== preferredSelector) {
+                    Log.w(TAG, "Preferred camera (front=$useFrontCamera) not present, falling back to the other lens")
+                }
+                return selector
+            }
+        }
+
+
+        Log.w(TAG, "Neither front nor back camera matched, using an unconstrained selector")
+        return CameraSelector.Builder().build()
     }
     
     

--- a/android/app/src/main/java/com/example/ava/camera/VideoCapture.kt
+++ b/android/app/src/main/java/com/example/ava/camera/VideoCapture.kt
@@ -106,10 +106,22 @@ class VideoCapture(private val context: Context) {
     
     private fun selectCamera(provider: ProcessCameraProvider, useFront: Boolean): CameraSelector {
         val preferred = if (useFront) CameraSelector.DEFAULT_FRONT_CAMERA else CameraSelector.DEFAULT_BACK_CAMERA
-        return runCatching {
-            preferred.filter(provider.availableCameraInfos)
-            preferred
-        }.getOrElse { CameraSelector.Builder().build() }
+        val fallback = if (useFront) CameraSelector.DEFAULT_BACK_CAMERA else CameraSelector.DEFAULT_FRONT_CAMERA
+
+        val availableCameras = runCatching { provider.availableCameraInfos }.getOrElse { emptyList() }
+
+        for (selector in listOf(preferred, fallback)) {
+            val matches = runCatching { selector.filter(availableCameras) }.getOrElse { emptyList() }
+            if (matches.isNotEmpty()) {
+                if (selector !== preferred) {
+                    Log.w(TAG, "Preferred camera (front=$useFront) not present, falling back to the other lens")
+                }
+                return selector
+            }
+        }
+
+        Log.w(TAG, "Neither front nor back camera matched, using an unconstrained selector")
+        return CameraSelector.Builder().build()
     }
     
     private fun processFrame(imageProxy: ImageProxy) {


### PR DESCRIPTION
## Problem

On a device that has **only one camera**, the camera feature can never work, and there is no way to fix it from the UI.

Reproduced on a Cyrus CM17XA_EEA (Android 10, `armeabi-v7a`) which has a single rear-facing lens:

```
dumpsys media.camera → "Number of camera devices: 1", "Device 0 ... Facing: Back"
pm list features     → no android.hardware.camera.front
```

Enabling **Remote Camera** creates the HA entities, but every capture fails:

```
E CameraService:  supportsCameraApi: Unknown camera ID 1
E CameraCapture:  Failed to bind camera
E CameraCapture:  java.lang.IllegalArgumentException: No available camera can be found
E VoiceSatelliteCamera: Failed to capture snapshot
```

## Root cause

`CameraCapture.selectCamera()` (and the identical `VideoCapture.selectCamera()`):

```kotlin
return runCatching {
    preferredSelector.filter(provider.availableCameraInfos)
    preferredSelector
}.getOrElse {
    CameraSelector.Builder().build()
}
```

`CameraSelector.filter()` **returns an empty list** when nothing matches — it does not throw. The
returned list is discarded, so `runCatching` always succeeds and the preferred selector is returned
even when that lens does not exist. `bindToLifecycle()` then throws `No available camera can be
found`, and the `getOrElse` fallback is never reached.

This is reachable by default: `ExperimentalSettingsScreen` defaults `cameraPosition` to `"FRONT"`
regardless of hardware —

```kotlin
val currentPosition = CameraPosition.valueOf(experimentalState?.cameraPosition ?: "FRONT")
```

— while the selector is disabled when only one lens is present:

```kotlin
val cameraOptions = buildList {
    if (hasFrontCamera) add(FRONT)
    if (hasBackCamera) add(BACK)
}
SelectSetting(..., enabled = cameraOptions.size > 1, ...)
```

So on a back-camera-only device the stored value stays `FRONT`, the picker is greyed out, and the
user has no way to correct it. `DeviceCapabilities.hasFrontCamera()` correctly reports `false` here
— the detection is fine; the default and the unreachable fallback are the problem.

## Fix

Check that the filtered list is actually non-empty, fall back to the other lens, and only then use
an unconstrained selector. Applied to both `CameraCapture` and `VideoCapture`.

```kotlin
for (selector in listOf(preferredSelector, fallbackSelector)) {
    val matches = runCatching { selector.filter(availableCameras) }.getOrElse { emptyList() }
    if (matches.isNotEmpty()) return selector
}
return CameraSelector.Builder().build()
```

The preferred lens still wins whenever it exists, so behaviour on normal two-camera devices is
unchanged. Devices with a single lens now bind to the one they have instead of failing.

## Note / possible follow-up

This fixes capture. The settings screen will still *display* "Front Camera" on a back-only device,
since the stored value remains `FRONT` and the picker stays disabled. Defaulting `cameraPosition`
to the first available camera would make the UI match reality — happy to add that here if you'd
prefer it in one PR.

## Testing

I can only verify the failing path on my hardware (single rear lens, Android 10) — I have not
built the patched APK, so this is a source-level fix reviewed against the CameraX contract for
`CameraSelector.filter()`. Please treat the two-camera regression check as unverified on my side.
