### PR TITLE
Add a flashlight switch

### DIFF
--- a/android/app/src/main/java/com/example/ava/camera/TorchController.kt
+++ b/android/app/src/main/java/com/example/ava/camera/TorchController.kt
@@ -1,0 +1,119 @@
+package com.example.ava.camera
+
+import android.content.Context
+import android.hardware.camera2.CameraAccessException
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Controls the device flashlight, independently of any camera session.
+ *
+ * Deliberately uses [CameraManager.setTorchMode] rather than CameraX's `CameraControl.enableTorch`:
+ * the CameraX route needs a camera bound to a lifecycle, so the torch could only be lit while a
+ * snapshot or video stream happened to be running, and it would go dark again the moment that
+ * session ended. `setTorchMode` works with the camera closed, which is what makes a flashlight
+ * useful on its own — and it means the torch does not compete with [CameraCapture] or
+ * [VideoCapture] for the camera. It also needs no CAMERA permission.
+ *
+ * Reported state comes from the system's own [CameraManager.TorchCallback] rather than from the
+ * last value that was requested, so it stays truthful when something else turns the torch off —
+ * which happens when another app opens that camera, or when the device gets too hot.
+ */
+class TorchController(private val context: Context) {
+
+    companion object {
+        private const val TAG = "TorchController"
+    }
+
+    private val cameraManager by lazy {
+        context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+    }
+
+    private val _state = MutableStateFlow(false)
+    val state: StateFlow<Boolean> = _state
+
+    private var cameraId: String? = null
+    private var torchCallback: CameraManager.TorchCallback? = null
+
+    /** True when any camera on this device reports a flash unit. */
+    fun isAvailable(): Boolean = findTorchCameraId() != null
+
+    /** Begins tracking torch state. Safe to call more than once. */
+    fun start() {
+        if (torchCallback != null) return
+        val id = findTorchCameraId() ?: return
+        cameraId = id
+
+        val callback = object : CameraManager.TorchCallback() {
+            override fun onTorchModeChanged(changedId: String, enabled: Boolean) {
+                if (changedId == id) _state.value = enabled
+            }
+
+            override fun onTorchModeUnavailable(changedId: String) {
+                // Raised while another app holds the camera. The torch is off in that state, and
+                // setTorchMode will fail until it is released.
+                if (changedId == id) _state.value = false
+            }
+        }
+        torchCallback = callback
+        cameraManager.registerTorchCallback(callback, Handler(Looper.getMainLooper()))
+    }
+
+    fun setEnabled(enabled: Boolean) {
+        val id = cameraId ?: return
+        try {
+            cameraManager.setTorchMode(id, enabled)
+        } catch (e: CameraAccessException) {
+            // Typically another app holding the camera, or a thermal block. Nothing to correct
+            // here: the callback above reports what the torch is actually doing.
+            Log.w(TAG, "Could not switch torch ${if (enabled) "on" else "off"}: ${e.message}")
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "Camera $id no longer supports a torch: ${e.message}")
+        }
+    }
+
+    /** Turns the torch off and stops tracking it, so it is never left lit after a shutdown. */
+    fun close() {
+        setEnabled(false)
+        torchCallback?.let {
+            runCatching { cameraManager.unregisterTorchCallback(it) }
+        }
+        torchCallback = null
+        cameraId = null
+        _state.value = false
+    }
+
+    /**
+     * Picks the camera whose flash to drive.
+     *
+     * Chosen by flash availability rather than by the configured capture lens: the torch is a light
+     * source, not the lens being captured from, and on the overwhelming majority of devices only
+     * the back camera reports a flash unit at all. Back is preferred when several qualify, and any
+     * camera with a flash is accepted rather than insisting on a particular facing — the same
+     * reasoning as the front/back fallback in the capture path.
+     */
+    private fun findTorchCameraId(): String? {
+        return try {
+            val withFlash = cameraManager.cameraIdList.filter { id ->
+                cameraManager.getCameraCharacteristics(id)
+                    .get(CameraCharacteristics.FLASH_INFO_AVAILABLE) == true
+            }
+            if (withFlash.isEmpty()) return null
+            withFlash.firstOrNull { id ->
+                cameraManager.getCameraCharacteristics(id)
+                    .get(CameraCharacteristics.LENS_FACING) == CameraCharacteristics.LENS_FACING_BACK
+            } ?: withFlash.first()
+        } catch (e: CameraAccessException) {
+            Log.w(TAG, "Could not enumerate cameras for a torch: ${e.message}")
+            null
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "Could not read camera characteristics for a torch: ${e.message}")
+            null
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/ava/esphome/voicesatellite/VoiceSatelliteCamera.kt
+++ b/android/app/src/main/java/com/example/ava/esphome/voicesatellite/VoiceSatelliteCamera.kt
@@ -32,6 +32,8 @@ class VoiceSatelliteCamera(
     private var videoCapture: com.example.ava.camera.VideoCapture? = null
     private var videoCameraEntity: CameraEntity? = null
     private var isRecording = false
+    private var torchController: com.example.ava.camera.TorchController? = null
+    private var torchEntity: SwitchEntity? = null
     private var detectionEnabled = false
     private var personDetectedState = MutableStateFlow(false)
     private var personDetectedEntity: BinarySensorEntity? = null
@@ -89,6 +91,43 @@ class VoiceSatelliteCamera(
                 entity.sendImage(com.example.ava.camera.VideoCapture.createPlaceholderFromAsset(context, "camera_off.png", 320, 240))
             }
         }
+
+        initTorch()
+    }
+
+    /**
+     * Exposes the device flashlight as a switch.
+     *
+     * The torch does not need a camera session (see [com.example.ava.camera.TorchController]), so it
+     * works in either camera mode and while nothing is streaming. It is registered from both
+     * [initSnapshot] and [initVideo] — whichever the configured mode happens to call — and is
+     * idempotent, so it can equally be called on its own if the flashlight should be gated by
+     * something other than the camera being enabled.
+     *
+     * Devices with no flash unit get no entity at all, rather than a switch that does nothing.
+     */
+    fun initTorch() {
+        if (torchEntity != null) return
+
+        val controller = com.example.ava.camera.TorchController(context)
+        if (!controller.isAvailable()) {
+            Log.d(TAG, "No camera on this device reports a flash unit; skipping the flashlight entity")
+            return
+        }
+        controller.start()
+        torchController = controller
+
+        val entity = SwitchEntity(
+            key = 14,
+            name = context.getString(R.string.entity_torch),
+            objectId = "torch",
+            icon = "mdi:flashlight",
+            getState = controller.state,
+            entityCategory = EntityCategory.ENTITY_CATEGORY_NONE,
+            setState = { enabled -> controller.setEnabled(enabled) }
+        )
+        torchEntity = entity
+        device.addEntity(entity)
     }
 
     private suspend fun takeSnapshot() {
@@ -156,8 +195,10 @@ class VoiceSatelliteCamera(
                 }
             }
         }
+
+        initTorch()
     }
-    
+
     private suspend fun startVideoRecording() {
         if (isRecording) return
         val capture = videoCapture ?: return
@@ -276,6 +317,12 @@ class VoiceSatelliteCamera(
     fun close() {
         stopVideoRecording()
         closeDetection()
+        // Turns the torch off as well, so shutting the service down cannot leave the light on with
+        // nothing left to switch it off from.
+        torchController?.close()
+        torchEntity?.let { device.removeEntity(it) }
+        torchController = null
+        torchEntity = null
         cameraCapture = null
         videoCapture = null
     }

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -72,6 +72,7 @@
     <string name="entity_camera_snapshot">设备快照</string>
     <string name="entity_video_recording">开始录像</string>
     <string name="entity_camera_video">设备录制</string>
+    <string name="entity_torch">手电筒</string>
     <string name="entity_person_detected">检测到人脸</string>
     <string name="entity_male_count">男性数量</string>
     <string name="entity_female_count">女性数量</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="entity_camera_snapshot">Device Snapshot</string>
     <string name="entity_video_recording">Start Recording</string>
     <string name="entity_camera_video">Device Recording</string>
+    <string name="entity_torch">Flashlight</string>
     <string name="entity_person_detected">Face Detected</string>
     <string name="entity_male_count">Male Count</string>
     <string name="entity_female_count">Female Count</string>

--- a/wiki/Camera.md
+++ b/wiki/Camera.md
@@ -196,6 +196,33 @@ Ava auto-detects camera availability. If no camera is present, camera entities a
 | `camera.your_device_name_video_camera` | Video stream camera | Video |
 | `button.your_device_name_take_snapshot` | Trigger snapshot | Snapshot |
 | `switch.your_device_name_video_recording` | Toggle video recording | Video |
+| `switch.your_device_name_torch` | Flashlight | Both |
+
+### Flashlight
+
+The flashlight is controlled through `CameraManager.setTorchMode()`, so it does not need a camera
+session: it works with the camera closed, in either camera mode, and does not compete with
+snapshots or the video stream for the camera.
+
+Its state is reported from the system's torch callback rather than from the last command sent, so
+it stays correct when something else switches the torch off — which happens when another app opens
+that camera, or when the device gets too hot. Devices with no flash unit get no entity at all.
+
+Use it as a light for night snapshots:
+
+```yaml
+actions:
+  - action: switch.turn_on
+    target:
+      entity_id: switch.your_device_name_torch
+  - delay: "00:00:01"
+  - action: button.press
+    target:
+      entity_id: button.your_device_name_take_snapshot
+  - action: switch.turn_off
+    target:
+      entity_id: switch.your_device_name_torch
+```
 
 ### Face Detection Entities
 


### PR DESCRIPTION
Exposes the device torch to Home Assistant as `switch.<device>_torch`, so a camera device can light its own scene — useful for night snapshots on a device acting as a fixed camera.

Follows on from #163: with the single-lens fallback merged, a back-camera-only device works well as a camera, but there is no way to light what it is pointing at.

## Why `CameraManager.setTorchMode()` and not CameraX

CameraX’s `CameraControl.enableTorch()` needs a camera bound to a lifecycle. Since `CameraCapture` binds a temporary lifecycle per photo and `VideoCapture` only while recording, that route would let the torch be lit *only* while a capture was already running, and it would go dark the moment the session ended.

`setTorchMode()` works with the camera closed. That means the flashlight:

- is useful on its own, with nothing streaming
- works in both Snapshot and Video mode
- never competes with `CameraCapture` / `VideoCapture` for the camera
- needs no `CAMERA` permission

## State is observed, not assumed

State comes from `CameraManager.TorchCallback`, not from the last value requested, so it stays truthful when the system turns the torch off by itself — which it does when another app opens that camera (`onTorchModeUnavailable`) or when the device overheats. HA therefore sees the real state rather than a stale optimistic one.

## Camera selection

The camera whose flash is driven is chosen by **flash availability**, not by the configured capture lens: the torch is a light source rather than the lens being captured from, and on almost all devices only the back camera reports a flash unit. Back is preferred when several qualify, and any camera with a flash is accepted rather than insisting on a facing — the same reasoning as the front/back fallback in the capture path.

Devices with no flash unit get **no entity at all**, rather than a switch that silently does nothing.

## Registration

Registered from both `initSnapshot()` and `initVideo()` — whichever the configured mode calls — and `initTorch()` is idempotent, so you can equally call it on its own if you would rather gate the flashlight separately from the camera being enabled. `close()` turns the torch off, so shutting the service down cannot leave the light on with nothing left to switch it off from.

## Testing

Honest about this, as with #163: **I could not build or run it.** The repo does not compile from a clean checkout — `.gitignore` excludes 10 core source paths (`VoiceSatellite.kt`, `Navigation.kt`, `SettingsScreen.kt`, `MdiIconMapper.kt`, the `bluetooth/` package, …), so `:app:compileDebugKotlin` fails with 40 unresolved references in `VoiceSatelliteService.kt`, `VinylCoverService.kt`, `MainActivity.kt`, `QuickEntityOverlayService.kt` and `VoiceSatelliteStateMachine.kt`.

What I could verify:

- **No error in either file I touched.** All 40 errors are in those five files; Kotlin analyses every source in the module, so `VoiceSatelliteCamera.kt` resolving cleanly covers `initTorch()`, the `TorchController` reference and `R.string.entity_torch`.
- **`TorchController.kt` compiles clean** — it depends only on the Android framework and coroutines, so I compiled it inside an unrelated Android project that does build: no errors, no warnings.

Please give the runtime behaviour a look on real hardware before merging, particularly the `onTorchModeUnavailable` path.

## Translations

Added `entity_torch` to `values` (English) and `values-zh` (手电筒). `values-pt`, `values-ru` and `values-vi` will fall back to English — happy to add them if you would like, but I did not want to guess at the register you use in those.